### PR TITLE
Avoid uninitialized warning

### DIFF
--- a/src/liboauthcpp.cpp
+++ b/src/liboauthcpp.cpp
@@ -453,7 +453,7 @@ std::string Client::buildOAuthParameterString(
         separator = ",";
         do_urlencode = false;
     }
-    else if (string_type == QueryStringString) {
+    else { // QueryStringString
         separator = "&";
         do_urlencode = true;
     }


### PR DESCRIPTION
Very simple change to avoid an uninitialized warning
