### PR TITLE
Fix signature generation issues preventing auth towards Twitter

### DIFF
--- a/src/urlencode.cpp
+++ b/src/urlencode.cpp
@@ -1,5 +1,50 @@
 #include "urlencode.h"
 #include <cassert>
+#include <sstream>
+#include <iomanip>
+
+inline bool isUnreserved(char c)
+{
+    switch (c)
+    {
+        case '0': case '1': case '2': case '3': case '4':
+        case '5': case '6': case '7': case '8': case '9':
+
+        case 'A': case 'B': case 'C': case 'D': case 'E':
+        case 'F': case 'G': case 'H': case 'I': case 'J':
+        case 'K': case 'L': case 'M': case 'N': case 'O':
+        case 'P': case 'Q': case 'R': case 'S': case 'T':
+        case 'U': case 'V': case 'W': case 'X': case 'Y':
+        case 'Z':
+
+        case 'a': case 'b': case 'c': case 'd': case 'e':
+        case 'f': case 'g': case 'h': case 'i': case 'j':
+        case 'k': case 'l': case 'm': case 'n': case 'o':
+        case 'p': case 'q': case 'r': case 's': case 't':
+        case 'u': case 'v': case 'w': case 'x': case 'y':
+        case 'z':
+
+        case '-': case '.': case '_': case '~':
+            return true;
+
+        default:
+            return false;
+    }
+}
+
+inline bool isSubDelim(char c)
+{
+    switch (c)
+    {
+        case '!': case '$': case '&': case '\'': case '(':
+        case ')': case '*': case '+': case ',':  case ';':
+        case '=':
+            return true;
+
+        default:
+            return false;
+    }
+}
 
 std::string char2hex( char dec )
 {
@@ -16,87 +61,43 @@ std::string char2hex( char dec )
 	return r;
 }
 
-std::string urlencode( const std::string &c, URLEncodeType enctype)
+std::string urlencode( const std::string &s, URLEncodeType enctype)
 {
+    std::stringstream escaped;
 
-    std::string escaped;
-	int max = c.length();
-	for(int i=0; i<max; i++)
-	{
-            // Unreserved chars
-		if ( (48 <= c[i] && c[i] <= 57) ||//0-9
-			(65 <= c[i] && c[i] <= 90) ||//ABC...XYZ
-			(97 <= c[i] && c[i] <= 122) || //abc...xyz
-			(c[i]=='~' || c[i]=='-' || c[i]=='_' || c[i]=='.')
-			)
-		{
-			escaped.append( &c[i], 1);
-		}
-                else if (c[i] != ':' && c[i] != '/' && c[i] != '?' && c[i] != '#' &&
-                    c[i] != '[' && c[i] != ']' && c[i] != '@' && c[i] != '%' &&
+    std::string::const_iterator itStr = s.begin();
+    for (; itStr != s.end(); ++itStr)
+    {
+        char c = *itStr;
 
-                    c[i] != '!' && c[i] != '$' && c[i] != '&' && c[i] != '\'' &&
-                    c[i] != '(' && c[i] != ')' && c[i] != '*' && c[i] != '+' &&
-                    c[i] != ',' && c[i] != ';' && c[i] != '=')
+        // Unreserved chars - never percent-encoded
+        if (isUnreserved(c))
+        {
+            escaped << c;
+            continue;
+        }
+
+        // Further on, the encoding depends on the context (where in the
+        // URI we are, what type of URI, and which character).
+        switch (enctype)
+        {
+            case URLEncode_Path:
+                if (isSubDelim(c))
                 {
-                    // Characters not in unreserved (first if block) and not in
-                    // the reserved set are always encoded.
-                    escaped.append("%");
-                    escaped.append( char2hex(c[i]) );//converts char 255 to string "FF"
+                    escaped << c;
+                    continue;
                 }
-		else
-		{
-                    // Finally, the reserved set. Encoding here depends on the
-                    // context (where in the URI we are, what type of URI, and
-                    // which character).
+                /* fall-through */
 
-                    bool enc = false;
+            case URLEncode_Everything:
+                escaped << '%' << char2hex(c);
+                break;
 
-                    // Always encode reserved gen-delims + '%' (which always
-                    // needs encoding
-                    if (c[i] == ':' || c[i] == '/' || c[i] == '?' || c[i] == '#' ||
-                        c[i] == '[' || c[i] == ']' || c[i] == '@' || c[i] == '%')
-                    {
-                        enc = true;
-                    }
-                    else {
-                        switch (enctype) {
-                          case URLEncode_Everything:
-                            enc = true;
-                            break;
-                          case URLEncode_Path:
-                            // Only reserved sub-delim that needs encoding is %,
-                            // taken care of above. Otherwise, leave unencoded
-                            enc = false;
-                            break;
-                          case URLEncode_QueryKey:
-                            if (c[i] == '&' ||
-                                c[i] == '+' ||
-                                c[i] == '=')
-                                enc = true;
-                            else
-                                enc = false;
-                            break;
-                          case URLEncode_QueryValue:
-                            if (c[i] == '&' ||
-                                c[i] == '+')
-                                enc = true;
-                            else
-                                enc = false;
-                            break;
-                          default:
-                            assert(false && "Unknown urlencode type");
-                            break;
-                        }
-                    }
+            default:
+                assert(false && 'Unknown urlencode type');
+                break;
+        }
+    }
 
-                    if (enc) {
-                        escaped.append("%");
-                        escaped.append( char2hex(c[i]) );//converts char 255 to string "FF"
-                    } else {
-			escaped.append( &c[i], 1);
-                    }
-		}
-	}
-	return escaped;
+    return escaped.str();
 }

--- a/src/urlencode.h
+++ b/src/urlencode.h
@@ -8,9 +8,9 @@ std::string char2hex( char dec );
 enum URLEncodeType {
     URLEncode_Everything,
     URLEncode_Path,
-    URLEncode_QueryKey,
-    URLEncode_QueryValue,
+    URLEncode_QueryKey = URLEncode_Everything, /* bkwds compatibility */
+    URLEncode_QueryValue = URLEncode_Everything,
 };
-std::string urlencode( const std::string &c, URLEncodeType enctype );
+std::string urlencode( const std::string &s, URLEncodeType enctype );
 
 #endif // __URLENCODE_H__

--- a/tests/request_test.h
+++ b/tests/request_test.h
@@ -81,6 +81,11 @@ public:
             "a=2&d=baz&oauth_consumer_key=wwwwxxxxyyyyzzzz&oauth_nonce=139026898664&oauth_signature=yqbgvxoqF0eyFqNGUaivRRRld8U%3D&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1390268986&oauth_token=aaaabbbbccccdddd&oauth_version=1.0&z=1",
             "Validate simple PUT request with unordered parameters signature"
         );
+        ASSERT_EQUAL(
+            oauth.getURLQueryString(OAuth::Http::Post, "resource?z=1&a=2&l=-74%2C40%2C-73%2C41"),
+            "a=2&l=-74%2C40%2C-73%2C41&oauth_consumer_key=wwwwxxxxyyyyzzzz&oauth_nonce=139026898664&oauth_signature=QXyCmnX%2FL3OR6wQ9HpZGrTk7ZG0%3D&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1390268986&oauth_token=aaaabbbbccccdddd&oauth_version=1.0&z=1",
+            "Validate simple POST request with sub-delimiter character ','"
+        );
     }
 };
 

--- a/tests/urlencode_test.h
+++ b/tests/urlencode_test.h
@@ -150,20 +150,20 @@ public:
         ASSERT_EQUAL(HttpEncodeQueryKey("]"), "%5D", "Reserved gen-delim '[' should be percent encoded (http query string encoding)");
         ASSERT_EQUAL(HttpEncodeQueryKey("@"), "%40", "Reserved gen-delim '@' should be percent encoded (http query string encoding)");
         // Reserved sub-delims
-        ASSERT_EQUAL(HttpEncodeQueryKey("!"), "!", "Reserved sub-delim '!' should be a nop (http query string encoding)");
-        ASSERT_EQUAL(HttpEncodeQueryKey("$"), "$", "Reserved sub-delim '$' should be a nop (http query string encoding)");
+        ASSERT_EQUAL(HttpEncodeQueryKey("!"), "%21", "Reserved sub-delim '!' should be percent encoded (http query string encoding)");
+        ASSERT_EQUAL(HttpEncodeQueryKey("$"), "%24", "Reserved sub-delim '$' should be percent encoded (http query string encoding)");
         ASSERT_EQUAL(HttpEncodeQueryKey("%"), "%25", "Reserved sub-delim '%' should be percent encoded (http query string encoding)");
         //  - '&' is the query arg separator
         ASSERT_EQUAL(HttpEncodeQueryKey("&"), "%26", "Reserved sub-delim '&' should be percent encoded (http query string encoding)");
-        ASSERT_EQUAL(HttpEncodeQueryKey("'"), "'", "Reserved sub-delim ''' should be a nop (http query string encoding)");
-        ASSERT_EQUAL(HttpEncodeQueryKey("("), "(", "Reserved sub-delim '(' should be a nop (http query string encoding)");
-        ASSERT_EQUAL(HttpEncodeQueryKey(")"), ")", "Reserved sub-delim ')' should be a nop (http query string encoding)");
-        ASSERT_EQUAL(HttpEncodeQueryKey("*"), "*", "Reserved sub-delim '*' should be a nop (http query string encoding)");
+        ASSERT_EQUAL(HttpEncodeQueryKey("'"), "%27", "Reserved sub-delim ''' should be percent encoded (http query string encoding)");
+        ASSERT_EQUAL(HttpEncodeQueryKey("("), "%28", "Reserved sub-delim '(' should be percent encoded (http query string encoding)");
+        ASSERT_EQUAL(HttpEncodeQueryKey(")"), "%29", "Reserved sub-delim ')' should be percent encoded (http query string encoding)");
+        ASSERT_EQUAL(HttpEncodeQueryKey("*"), "%2A", "Reserved sub-delim '*' should be percent encoded (http query string encoding)");
         //  - '+' has to be encoded in query strings because spaces historically
         //    were convereted to '+'.
         ASSERT_EQUAL(HttpEncodeQueryKey("+"), "%2B", "Reserved sub-delim '+' should be percent encoded (http query string encoding)");
-        ASSERT_EQUAL(HttpEncodeQueryKey(","), ",", "Reserved sub-delim ',' should be a nop (http query string encoding)");
-        ASSERT_EQUAL(HttpEncodeQueryKey(";"), ";", "Reserved sub-delim ';' should be a nop (http query string encoding)");
+        ASSERT_EQUAL(HttpEncodeQueryKey(","), "%2C", "Reserved sub-delim ',' should be percent encoded (http query string encoding)");
+        ASSERT_EQUAL(HttpEncodeQueryKey(";"), "%3B", "Reserved sub-delim ';' should be percent encoded (http query string encoding)");
         //  - '=' is the key=value separator
         ASSERT_EQUAL(HttpEncodeQueryKey("="), "%3D", "Reserved sub-delim '=' should be percent encoded (http query string encoding)");
 
@@ -205,22 +205,22 @@ public:
         ASSERT_EQUAL(HttpEncodeQueryValue("]"), "%5D", "Reserved gen-delim '[' should be percent encoded (http query string encoding)");
         ASSERT_EQUAL(HttpEncodeQueryValue("@"), "%40", "Reserved gen-delim '@' should be percent encoded (http query string encoding)");
         // Reserved sub-delims
-        ASSERT_EQUAL(HttpEncodeQueryValue("!"), "!", "Reserved sub-delim '!' should be a nop (http query string encoding)");
-        ASSERT_EQUAL(HttpEncodeQueryValue("$"), "$", "Reserved sub-delim '$' should be a nop (http query string encoding)");
+        ASSERT_EQUAL(HttpEncodeQueryValue("!"), "%21", "Reserved sub-delim '!' should be percent encoded (http query string encoding)");
+        ASSERT_EQUAL(HttpEncodeQueryValue("$"), "%24", "Reserved sub-delim '$' should be percent encoded (http query string encoding)");
         ASSERT_EQUAL(HttpEncodeQueryValue("%"), "%25", "Reserved sub-delim '%' should be percent encoded (http query string encoding)");
         //  - '&' is the query arg separator
         ASSERT_EQUAL(HttpEncodeQueryValue("&"), "%26", "Reserved sub-delim '&' should be percent encoded (http query string encoding)");
-        ASSERT_EQUAL(HttpEncodeQueryValue("'"), "'", "Reserved sub-delim ''' should be a nop (http query string encoding)");
-        ASSERT_EQUAL(HttpEncodeQueryValue("("), "(", "Reserved sub-delim '(' should be a nop (http query string encoding)");
-        ASSERT_EQUAL(HttpEncodeQueryValue(")"), ")", "Reserved sub-delim ')' should be a nop (http query string encoding)");
-        ASSERT_EQUAL(HttpEncodeQueryValue("*"), "*", "Reserved sub-delim '*' should be a nop (http query string encoding)");
+        ASSERT_EQUAL(HttpEncodeQueryValue("'"), "%27", "Reserved sub-delim ''' should be percent encoded (http query string encoding)");
+        ASSERT_EQUAL(HttpEncodeQueryValue("("), "%28", "Reserved sub-delim '(' should be percent encoded (http query string encoding)");
+        ASSERT_EQUAL(HttpEncodeQueryValue(")"), "%29", "Reserved sub-delim ')' should be percent encoded (http query string encoding)");
+        ASSERT_EQUAL(HttpEncodeQueryValue("*"), "%2A", "Reserved sub-delim '*' should be percent encoded (http query string encoding)");
         //  - '+' has to be encoded in query strings because spaces historically
         //    were convereted to '+'.
         ASSERT_EQUAL(HttpEncodeQueryValue("+"), "%2B", "Reserved sub-delim '+' should be percent encoded (http query string encoding)");
-        ASSERT_EQUAL(HttpEncodeQueryValue(","), ",", "Reserved sub-delim ',' should be a nop (http query string encoding)");
-        ASSERT_EQUAL(HttpEncodeQueryValue(";"), ";", "Reserved sub-delim ';' should be a nop (http query string encoding)");
+        ASSERT_EQUAL(HttpEncodeQueryValue(","), "%2C", "Reserved sub-delim ',' should be percent encoded (http query string encoding)");
+        ASSERT_EQUAL(HttpEncodeQueryValue(";"), "%3B", "Reserved sub-delim ';' should be percent encoded (http query string encoding)");
         //  - '=' is the key=value separator, but is safe in the values
-        ASSERT_EQUAL(HttpEncodeQueryValue("="), "=", "Reserved sub-delim '=' should be a nop (http query string encoding)");
+        ASSERT_EQUAL(HttpEncodeQueryValue("="), "%3D", "Reserved sub-delim '=' should be percent encoded (http query string encoding)");
 
 
         // Try to cover a reasonable set of non-unreserved


### PR DESCRIPTION
Introduce a configuration option to enable percent-encoding of every character neither in the unreserved, nor in the reserved set, as requested by https://dev.twitter.com/oauth/overview/percent-encoding-parameters (without this, a request containing e.g. a comma, such as the location filter: locations=-74,40,-73,41 is never authorized by Twitter).

~~Also fix incorrect parameter normalization in OAuth signature base string construction - the parameters and their values should be (percent-)**encoded first**, and only after encoding, should they be sorted etc. (as requested by both https://tools.ietf.org/html/rfc5849#section-3.4.1.3.2 and https://dev.twitter.com/oauth/overview/creating-signatures)~~

Scratch that, now I realize I've been using the library wrong... I assumed "rawURL" and "rawData" means "not URI-encoded", when its actually the exact opposite of that.

Before:

```
OAUTH: Signing request POST https://stream.twitter.com/1.1/statuses/filter.json?delimited=length&stall_warnings=true locations=-74,40,-73,41
OAUTH: Normalized parameters: delimited=length&locations=-74,40,-73,41&oauth_consumer_key=...&oauth_nonce=1494440318bb13e40&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1494440318&oauth_token=...&oauth_version=1.0&stall_warnings=true
OAUTH: Signature base string: POST&https%3A%2F%2Fstream.twitter.com%2F1.1%2Fstatuses%2Ffilter.json&delimited%3Dlength%26locations%3D-74%2C40%2C-73%2C41%26oauth_consumer_key%3D...%26oauth_nonce%3D1494440318bb13e40%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D1494440318%26oauth_token%3D...%26oauth_version%3D1.0%26stall_warnings%3Dtrue
OAUTH: Signature: o2u5/lC0Y6ysxxkmBZm1bzqMuh8=
OAUTH: Percent-encoded Signature: o2u5%2FlC0Y6ysxxkmBZm1bzqMuh8%3D
```

After:

```
OAUTH: Signing request POST https://stream.twitter.com/1.1/statuses/filter.json?delimited=length&stall_warnings=true locations=-74,40,-73,41
OAUTH: Normalized parameters: delimited=length&locations=-74%2C40%2C-73%2C41&oauth_consumer_key=...&oauth_nonce=1494441992422d7b7f&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1494441992&oauth_token=...&oauth_version=1.0&stall_warnings=true
OAUTH: Signature base string: POST&https%3A%2F%2Fstream.twitter.com%2F1.1%2Fstatuses%2Ffilter.json&delimited%3Dlength%26locations%3D-74%252C40%252C-73%252C41%26oauth_consumer_key%3D...%26oauth_nonce%3D1494441992422d7b7f%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D1494441992%26oauth_token%3D...%26oauth_version%3D1.0%26stall_warnings%3Dtrue
OAUTH: Signature: 0mOZDChSh0Bqs99ShVpm2LbKcnA=
OAUTH: Percent-encoded Signature: 0mOZDChSh0Bqs99ShVpm2LbKcnA%3D
```