### PR TITLE
Check for MSVC instead of WIN32 when adding MSVC-specific flags

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -34,7 +34,7 @@ PROJECT(liboauthcpp C CXX)
 ENABLE_LANGUAGE(C)
 
 # Disable some annoying, unnecessary Windows warnings. Enable unwinding for exception handlers.
-IF(WIN32)
+IF(MSVC)
   ADD_DEFINITIONS(-D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_WARNINGS -EHsc)
   SET(CMAKE_CXX_FLAGS "-D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_WARNINGS")
 ENDIF()


### PR DESCRIPTION
Replacing the WIN32 CMake flag check for a more specific MSVC check, allowing use of non-MS compilers in the win32 environment (MSYS2, MinGW, etc).