### PR TITLE
Changes to make ETrade work

### DIFF
--- a/include/liboauthcpp/liboauthcpp.h
+++ b/include/liboauthcpp/liboauthcpp.h
@@ -203,8 +203,10 @@ public:
     std::string getHttpHeader(const Http::RequestType eType,
                          const std::string& rawUrl,
                          const std::string& rawData = "",
+                         const KeyValuePairs& additional_keys = {},
                          const bool includeOAuthVerifierPin = false) const;
-    /** Build an OAuth HTTP header for the given request. This version gives a
+
+     /** Build an OAuth HTTP header for the given request. This version gives a
      *  fully formatted header, i.e. including the header field name.
      *
      *  \param eType the HTTP request type, e.g. GET or POST
@@ -270,7 +272,8 @@ private:
         const Http::RequestType eType,
         const std::string& rawUrl,
         const std::string& rawData,
-        const bool includeOAuthVerifierPin) const;
+        const bool includeOAuthVerifierPin,
+        const KeyValuePairs& additionalKeyPairs = {}) const;
 
     bool getSignature( const Http::RequestType eType, /* in */
                        const std::string& rawUrl, /* in */


### PR DESCRIPTION
Hey there,

I made some changes to your library to make ETrade work.  The primary change is adding a parameter to add additional key/value pairs when getting an HTTP header, but I also changed it so that URL encoding is done for Authorization headers as well as query URLs.

If you know of a case where Authorization headers should definitely _NOT_ be URL encoded, you may wish to make this a parameter instead of accepting my change as-is.  However, the only way to make ETrade work was by flipping that boolean, so it should definitely be an option.

This is a very useful library.  Thanks for writing it, and have a nice day.